### PR TITLE
Feature/s3 url

### DIFF
--- a/dimension/extraction.go
+++ b/dimension/extraction.go
@@ -96,12 +96,13 @@ func (extract *Extract) Extract() (map[string]Request, error) {
 		extract.Dimensions[dimension+"_"+dimensionValue] = dimension
 
 		request := Request{
-			Attempt:        1,
-			Dimension:      dimension,
-			DimensionValue: dimensionValue,
-			ImportAPIURL:   extract.ImportAPIURL,
-			InstanceID:     extract.InstanceID,
-			MaxAttempts:    extract.MaxRetries,
+			Attempt:            1,
+			Dimension:          dimension,
+			DimensionValue:     dimensionValue,
+			ImportAPIURL:       extract.ImportAPIURL,
+			ImportAPIAuthToken: extract.ImportAPIAuthToken,
+			InstanceID:         extract.InstanceID,
+			MaxAttempts:        extract.MaxRetries,
 		}
 
 		dimensions[dimension] = request

--- a/dimension/extraction_test.go
+++ b/dimension/extraction_test.go
@@ -38,8 +38,8 @@ func TestUnitExtract(t *testing.T) {
 		Convey("where all dimensions are unique", func() {
 			dimensions, err := extract.Extract()
 			So(err, ShouldBeNil)
-			So(dimensions["123_Time"], ShouldResemble, dimension.Request{Attempt: 1, Dimension: "123_Time", DimensionValue: "2016/17", ImportAPIURL: extract.ImportAPIURL, InstanceID: extract.InstanceID, MaxAttempts: 3})
-			So(dimensions["123_League"], ShouldResemble, dimension.Request{Attempt: 1, Dimension: "123_League", DimensionValue: "PL01", ImportAPIURL: extract.ImportAPIURL, InstanceID: extract.InstanceID, MaxAttempts: 3})
+			So(dimensions["123_Time"], ShouldResemble, dimension.Request{Attempt: 1, Dimension: "123_Time", DimensionValue: "2016/17", ImportAPIURL: extract.ImportAPIURL, ImportAPIAuthToken:extract.ImportAPIAuthToken, InstanceID: extract.InstanceID, MaxAttempts: 3})
+			So(dimensions["123_League"], ShouldResemble, dimension.Request{Attempt: 1, Dimension: "123_League", DimensionValue: "PL01", ImportAPIURL: extract.ImportAPIURL, ImportAPIAuthToken:extract.ImportAPIAuthToken, InstanceID: extract.InstanceID, MaxAttempts: 3})
 		})
 
 		Convey("where some dimensions are unique", func() {
@@ -47,7 +47,7 @@ func TestUnitExtract(t *testing.T) {
 			extract.Dimensions["123_Year"] = "2015/16"
 			dimensions, err := extract.Extract()
 			So(err, ShouldBeNil)
-			So(dimensions["123_League"], ShouldResemble, dimension.Request{Attempt: 1, Dimension: "123_League", DimensionValue: "Championship", ImportAPIURL: extract.ImportAPIURL, InstanceID: extract.InstanceID, MaxAttempts: 3})
+			So(dimensions["123_League"], ShouldResemble, dimension.Request{Attempt: 1, Dimension: "123_League", DimensionValue: "Championship", ImportAPIURL: extract.ImportAPIURL, ImportAPIAuthToken:extract.ImportAPIAuthToken, InstanceID: extract.InstanceID, MaxAttempts: 3})
 		})
 
 		Convey("where no dimensions are unique", func() {

--- a/dimension/request.go
+++ b/dimension/request.go
@@ -38,7 +38,7 @@ func (request *Request) Put(httpClient *http.Client) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Internal-token", request.ImportAPIAuthToken)
+	req.Header.Set("internal-token", request.ImportAPIAuthToken)
 
 	res, err := httpClient.Do(req)
 	if err != nil {

--- a/instance/request.go
+++ b/instance/request.go
@@ -56,7 +56,7 @@ func (instance *JobInstance) PutData(httpClient *http.Client) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Internal-token", instance.ImportAPIAuthToken)
+	req.Header.Set("internal-token", instance.ImportAPIAuthToken)
 
 	res, err := httpClient.Do(req)
 	if err != nil {

--- a/service/handler.go
+++ b/service/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ONSdigital/go-ns/kafka"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/s3"
+	"net/url"
 )
 
 type dimensionExtracted struct {
@@ -23,6 +24,15 @@ type dimensionExtracted struct {
 type inputFileAvailable struct {
 	FileURL    string `avro:"file_url"`
 	InstanceID string `avro:"instance_id"`
+}
+
+func (inputFileAvailable *inputFileAvailable) s3URL() (string, error) {
+	url, err := url.Parse(inputFileAvailable.FileURL)
+	if err != nil {
+		return "", err
+	}
+
+	return "s3:/" + url.Path, nil
 }
 
 // handleMessage handles a message by sending requests to the import API
@@ -116,10 +126,16 @@ func retrieveData(message kafka.Message, s3 *s3.S3) ([]byte, string, io.Reader, 
 		return nil, "", nil, err
 	}
 
-	log.Debug("event received", log.Data{"file_url": event.FileURL, "instance_id": event.InstanceID})
+	s3URL, err := event.s3URL()
+	if err != nil {
+		log.ErrorC("encountered error parsing file URL", err, log.Data{"instance_id": event.InstanceID})
+		return nil, event.InstanceID, nil, err
+	}
+
+	log.Debug("event received", log.Data{"file_url": event.FileURL, "s3_url": s3URL, "instance_id": event.InstanceID})
 
 	// Get csv from S3 bucket
-	file, err := s3.Get(event.FileURL)
+	file, err := s3.Get(s3URL)
 	if err != nil {
 		log.ErrorC("encountered error retrieving csv file", err, log.Data{"instance_id": event.InstanceID})
 		return nil, event.InstanceID, nil, err
@@ -128,7 +144,7 @@ func retrieveData(message kafka.Message, s3 *s3.S3) ([]byte, string, io.Reader, 
 	log.Debug("file successfully read from aws", log.Data{"instance_id": event.InstanceID})
 
 	producerMessage, err := schema.DimensionsExtractedSchema.Marshal(&dimensionExtracted{
-		FileURL:    event.FileURL,
+		FileURL:    s3URL,
 		InstanceID: event.InstanceID,
 	})
 

--- a/service/handler_test.go
+++ b/service/handler_test.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestSpec(t *testing.T) {
+
+	Convey("Given an inputFileAvailable event with a HTTP S3 URL", t, func() {
+
+		inputFileAvailable := &inputFileAvailable{
+			FileURL:"https://s3-eu-west-1.amazonaws.com/csv-exported/2137bad0-737c-4221-b75a-ce7ffd3042e1.csv",
+			InstanceID:"123",
+		}
+
+		Convey("When the s3URL function is called", func() {
+
+			s3URL, err := inputFileAvailable.s3URL()
+
+			Convey("The expected URL is returned with the S3 scheme", func() {
+				So(err, ShouldBeNil)
+				So(s3URL, ShouldEqual, "s3://csv-exported/2137bad0-737c-4221-b75a-ce7ffd3042e1.csv")
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

The dimension extractor required the s3 URL to be in the format with 's3' as the scheme. The front end passes in a URL with https as the scheme which fails. When a s3 URL is sent to the dimension extractor it now formats it to ensure its in the correct format.

There is also a bug fix for the import API auth token not being passed to requests.

### How to review

Check the code updates
Check that the dimension extractor works as expected - that it can make requests to the import API, and that it can handle any valid format of s3 URL.

### Who can review

Anyone
