### PR TITLE
Use filename in vaultpath

### DIFF
--- a/policy.hcl
+++ b/policy.hcl
@@ -1,3 +1,3 @@
-path "secret/shared/psk" {
+path "secret/shared/psk/*" {
   capabilities = ["read"]
 }

--- a/service/service.go
+++ b/service/service.go
@@ -208,7 +208,10 @@ func retrieveData(message kafka.Message, sess *session.Session, encryptionDisabl
 	if !encryptionDisabled {
 		client := s3crypto.New(sess, &s3crypto.Config{HasUserDefinedPSK: true})
 
-		pskStr, err := vc.ReadKey(vaultPath, filename)
+		path := vaultPath + "/" + filename
+		vaultKey := "key"
+
+		pskStr, err := vc.ReadKey(path, vaultKey)
 		if err != nil {
 			return nil, event.InstanceID, nil, err
 		}


### PR DESCRIPTION
### What

* Use filename in vaultpath

Intentionally merging into `feature/psk-decryption` as its where the initial decryption code exists. Requires the branch of the same name for florence and dp-observation-exporter.
