### PR TITLE
Lower case dimension names for comparison

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -74,7 +74,7 @@ func (svc *Service) HandleMessage(ctx context.Context, message kafka.Message) (s
 
 	codelistMap := make(map[string]string)
 	for _, cl := range codeLists.Dimensions {
-		codelistMap[cl.Name] = cl.ID
+		codelistMap[strings.ToLower(cl.Name)] = cl.ID
 	}
 
 	csvReader := csv.NewReader(file)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -38,9 +38,9 @@ var (
 			ID:         "versionId",
 			InstanceID: validInstanceID,
 			Dimensions: []dataset.VersionDimension{
-				dataset.VersionDimension{ID: "Time", Name: "time"},
-				dataset.VersionDimension{ID: "Geography", Name: "geography"},
-				dataset.VersionDimension{ID: "Aggregate", Name: "aggregate"},
+				dataset.VersionDimension{ID: "Time", Name: "Time"},
+				dataset.VersionDimension{ID: "Geography", Name: "Geography"},
+				dataset.VersionDimension{ID: "Aggregate", Name: "Aggregate"},
 			},
 		},
 	}


### PR DESCRIPTION

### What
- Lower case dimension names for comparison

Each dimension name is matched to the corresponding dimension name from the V4 input file. The dimension name in the input file is lower cases before it is comparsed, but the dimension name from the instance is not. The dimension name from the instance originates from the recipe. If the recipe dimension names are updated to be capitalised, this process would break.


### How to review
Review changes / check tests

### Who can review
Anyone
