### PR TITLE
Updated to dp-kafka v2.1.0, which reintroduced CommitAndRelease (msg lvl)

### DIFF
--- a/event/consumer.go
+++ b/event/consumer.go
@@ -54,8 +54,8 @@ func (c *Consumer) Start(eventLoopContext context.Context, eventLoopDone, servic
 				} else {
 					log.Event(kafkaContext, "event successfully processed", log.INFO, log.Data{"instance_id": instanceID})
 				}
-				message.Commit()
-				log.Event(eventLoopContext, "message committed", log.INFO, log.Data{"instance_id": instanceID})
+				message.CommitAndRelease()
+				log.Event(eventLoopContext, "message committed and released", log.INFO, log.Data{"instance_id": instanceID})
 			}
 		}
 	}()

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -59,7 +59,9 @@ func TestConsumer_Start(t *testing.T) {
 			})
 
 			Convey("And message.CommitAndRelease is called once", func() {
-				So(len(msg.CommitCalls()), ShouldEqual, 1)
+				So(msg.IsMarked(), ShouldBeTrue)
+				So(msg.IsCommitted(), ShouldBeTrue)
+				So(len(msg.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 
 			Convey("And errorReporter.Notify is never called", func() {
@@ -114,8 +116,10 @@ func TestConsumer_HandleMessageError(t *testing.T) {
 				So(len(handler.EventLoopContextArgs), ShouldEqual, 1)
 			})
 
-			Convey("And message.Commit is called once", func() {
-				So(len(msg.CommitCalls()), ShouldEqual, 1)
+			Convey("And message.CommitAndRelease is called once", func() {
+				So(msg.IsMarked(), ShouldBeTrue)
+				So(msg.IsCommitted(), ShouldBeTrue)
+				So(len(msg.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 
 			Convey("And errorReporter.Notify is called once", func() {
@@ -147,8 +151,10 @@ func TestConsumer_HandleMessageError(t *testing.T) {
 				So(len(handler.EventLoopContextArgs), ShouldEqual, 1)
 			})
 
-			Convey("And message.Commit is called once", func() {
-				So(len(msg.CommitCalls()), ShouldEqual, 1)
+			Convey("And message.CommitAndRelease is called once", func() {
+				So(msg.IsMarked(), ShouldBeTrue)
+				So(msg.IsCommitted(), ShouldBeTrue)
+				So(len(msg.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 
 			Convey("And errorReporter.Notify is never called", func() {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.9.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
-	github.com/ONSdigital/dp-kafka/v2 v2.0.3
+	github.com/ONSdigital/dp-kafka/v2 v2.1.0
 	github.com/ONSdigital/dp-reporter-client v1.0.1
 	github.com/ONSdigital/dp-s3 v1.4.0
 	github.com/ONSdigital/dp-vault v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAj
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-kafka/v2 v2.0.2 h1:GD8uF18bc7ub2vjvFm+5mfwtb4wRJiPunw1iTzAIttA=
 github.com/ONSdigital/dp-kafka/v2 v2.0.2/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
-github.com/ONSdigital/dp-kafka/v2 v2.0.3 h1:2y9IJqwd0j/j/g0Jc6VcPrOTh27YwqZE6DlixtL6cYc=
-github.com/ONSdigital/dp-kafka/v2 v2.0.3/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
+github.com/ONSdigital/dp-kafka/v2 v2.1.0 h1:xYWdTqyS7q7ps5KzmrKAgPvU9//EnioI8nsNv9RU7og=
+github.com/ONSdigital/dp-kafka/v2 v2.1.0/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=


### PR DESCRIPTION
### What

- Updated to dp-kafka 2.1.0, which reintroduces CommitAndRelease (at message level)
- Updated accordingly (msg.Commit() -> msg.CommitAndRelease())

### How to review

- Make sure code changes make sense (`CommitAndRelease` implements the same logic that `Commit` did in the dp-kafka v2.0.x)
- Make sure unit tests pass

### Who can review

Anyone
