### PR TITLE
Handle panics when handling messages

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 func TestSpec(t *testing.T) {
 	Convey("Given an environment with no environment variables set", t, func() {
+		os.Clearenv()
 		cfg, err := config.Get()
 
 		Convey("When the config values are retrieved", func() {

--- a/service/service.go
+++ b/service/service.go
@@ -60,6 +60,13 @@ type Service struct {
 // HandleMessage handles a message by sending requests to the dataset API
 // before producing a new message to confirm successful completion
 func (svc *Service) HandleMessage(ctx context.Context, message kafka.Message) (string, error) {
+
+	defer func() {
+		if err := recover(); err != nil {
+			log.Event(ctx, "panic in handle message", log.ERROR, log.Data{"err": err})
+		}
+	}()
+
 	producerMessage, instanceID, file, err := svc.retrieveData(ctx, message)
 	if err != nil {
 		return instanceID, err


### PR DESCRIPTION
### What
In the develop environment we are seeing this service exit in Nomad with exit code 2. There is no error shown in the logs. This leads me to believe that a panic is occurring, as Go will exit with code 2 on a panic: https://golang.org/pkg/runtime/

If a panic occurs within the handle message function it will bubble up to the application and cause it to exit. This change captures and logs any panic that occurs within HandleMessage, preventing the exit.

### How to review
Review changes / tests

### Who can review
Anyone
