### PR TITLE
Separate file read from dimension post

### DIFF
--- a/dimension/extraction_test.go
+++ b/dimension/extraction_test.go
@@ -18,7 +18,6 @@ var badCSVLine2 = []string{"20", "", "Year", "2016/17", "PL01", "Premier-League"
 var dimensionsData = make(map[string]string)
 
 var extract = &dimension.Extract{
-	Dimensions:            dimensionsData,
 	DimensionColumnOffset: 2,
 	HeaderRow:             headerRow,
 	Line:                  CSVLine,
@@ -38,7 +37,6 @@ func TestUnitExtract(t *testing.T) {
 
 	Convey("test creation of extract object/stuct", t, func() {
 		newExtract := &dimension.Extract{
-			Dimensions:            dimensionsData,
 			DimensionColumnOffset: 2,
 			HeaderRow:             headerRow,
 			InstanceID:            "123",
@@ -53,23 +51,8 @@ func TestUnitExtract(t *testing.T) {
 		Convey("where all dimensions are unique", func() {
 			dimensions, err := extract.Extract()
 			So(err, ShouldBeNil)
-			So(dimensions["123_Time"], ShouldResemble, dataset.OptionPost{Name: "time", Option: "2016/17", Code: "Year", Label: "2016/17", CodeList: "1234-435435-5675"})
-			So(dimensions["123_League"], ShouldResemble, dataset.OptionPost{Name: "league", Option: "PL01", Code: "PL01", Label: "Premier-League", CodeList: "dgdfg-435435-5675"})
-		})
-
-		Convey("where some dimensions are unique", func() {
-			extract.Line = CSVLine2
-			extract.Dimensions["123_Year"] = "2015/16"
-			dimensions, err := extract.Extract()
-			So(err, ShouldBeNil)
-			So(dimensions["123_League"], ShouldResemble, dataset.OptionPost{Name: "league", Option: "Championship", Label: "Championship", CodeList: "dgdfg-435435-5675"})
-		})
-
-		Convey("where no dimensions are unique", func() {
-			extract.Line = CSVLine2
-			dimensions, err := extract.Extract()
-			So(err, ShouldBeNil)
-			So(dimensions["123_League"], ShouldResemble, dataset.OptionPost{Name: "", Option: ""})
+			So(dimensions["Time_2016/17"], ShouldResemble, dataset.OptionPost{Name: "time", Option: "2016/17", Code: "Year", Label: "2016/17", CodeList: "1234-435435-5675"})
+			So(dimensions["League_PL01"], ShouldResemble, dataset.OptionPost{Name: "league", Option: "PL01", Code: "PL01", Label: "Premier-League", CodeList: "dgdfg-435435-5675"})
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/aws/aws-sdk-go v1.29.29
-	github.com/davecgh/go-spew v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/smartystreets/goconvey v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/ONSdigital/dp-reporter-client v1.0.1 h1:9ds+ZROIlvScbkis6x9dZCuSC67D9
 github.com/ONSdigital/dp-reporter-client v1.0.1/go.mod h1:i4PajSeDB6Ber2VzyzDlRjrMKqVZGAgM2Hcq9Fg1uWo=
 github.com/ONSdigital/dp-s3 v1.4.0 h1:qpWy4yttSEsJQrPDotFSzfv8JXx8m73Zgy5yo9HKyRE=
 github.com/ONSdigital/dp-s3 v1.4.0/go.mod h1:5bZUUdWajH/La/YOYhFOdr8opzmJQEdgfm5bK2mzsgI=
+github.com/ONSdigital/dp-s3 v1.5.1 h1:BpWqWyg8PCXsEIEEtDTFWhb/lV6GhHALfGn8YS93p1I=
+github.com/ONSdigital/dp-s3 v1.5.1/go.mod h1:dQEoujkOIQciAItcN/fYKQVUD5rittrnUB22R5oB0Qs=
 github.com/ONSdigital/dp-vault v1.1.1 h1:oenA0oci08viJrg5kGY+jTaX9jGWNOKyIEZCTbDAaQM=
 github.com/ONSdigital/dp-vault v1.1.1/go.mod h1:ZcC6ZNL4c94JCKK4a8uVUcMBTiMg5zdn/e7ZIYUGeh8=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
@@ -211,7 +213,6 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/service/service.go
+++ b/service/service.go
@@ -139,7 +139,6 @@ func (svc *Service) HandleMessage(ctx context.Context, message kafka.Message) (s
 				continue
 			}
 
-			log.Event(ctx, "adding dimension to post", log.INFO, log.Data{"instance_id": instanceID, "dimension_option": optionKey})
 			dimensionOptions[optionKey] = optionToPost
 			numberOfOptions++
 		}
@@ -154,9 +153,6 @@ func (svc *Service) HandleMessage(ctx context.Context, message kafka.Message) (s
 	})
 
 	for optionKey, optionToPost := range dimensionOptions {
-
-		log.Event(ctx, "posting dimension option", log.INFO, log.Data{"instance_id": instanceID, "dimension_option": optionKey})
-
 		if err := svc.DatasetClient.PostInstanceDimensions(ctx, svc.AuthToken, instanceID, optionToPost); err != nil {
 			log.Event(ctx, "encountered error sending request to dataset api", log.ERROR, log.Error(err), log.Data{"instance_id": instanceID, "dimension_option": optionKey})
 			return instanceID, err

--- a/service/service.go
+++ b/service/service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"encoding/csv"
 	"encoding/hex"
-	"fmt"
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-dimension-extractor/dimension"
 	"github.com/ONSdigital/dp-dimension-extractor/schema"
@@ -13,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"golang.org/x/net/context"
 	"io"
-	"runtime/debug"
 	"strconv"
 	"strings"
 )
@@ -61,16 +59,6 @@ type Service struct {
 // HandleMessage handles a message by sending requests to the dataset API
 // before producing a new message to confirm successful completion
 func (svc *Service) HandleMessage(ctx context.Context, message kafka.Message) (string, error) {
-
-	defer func() {
-		if err := recover(); err != nil {
-			log.Event(ctx, "panic in handle message", log.ERROR,
-				log.Data{
-					"err":   fmt.Sprintf("%+v", err),
-					"stack": string(debug.Stack()),
-				})
-		}
-	}()
 
 	producerMessage, instanceID, file, err := svc.retrieveData(ctx, message)
 	if err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -141,34 +141,6 @@ func TestS3URL(t *testing.T) {
 
 func TestHandleMessage(t *testing.T) {
 
-	Convey("Given a panic occurs when GetInstance is called ", t, func() {
-		datasetClient := &mock.DatasetClientMock{
-			GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string) (dataset.Instance, error) {
-				panic("panic message")
-			},
-		}
-		mockS3Client := &mock.S3ClientMock{GetFunc: mockGetFunc, GetWithPSKFunc: mockGetWithPskFunc}
-		svc := &service.Service{
-			AuthToken:                  validAuthToken,
-			DimensionExtractedProducer: &mock.KafkaProducerMock{},
-			EncryptionDisabled:         true,
-			DatasetClient:              datasetClient,
-			AwsSession:                 nil,
-			S3Clients:                  map[string]service.S3Client{validBucket: mockS3Client},
-			VaultClient:                &mock.VaultClientMock{},
-			VaultPath:                  validVaultPath,
-		}
-
-		Convey("When HandleMessage is called with a valid message", func(c C) {
-
-			_, err := svc.HandleMessage(ctx, createValidMessage())
-
-			Convey("Then no panic should occur", func(c C) {
-				So(err, ShouldBeNil)
-			})
-		})
-	})
-
 	Convey("Given the intention to Handle a message ", t, func() {
 		mockVaultClient := &mock.VaultClientMock{ReadKeyFunc: mockReadKeyFunc}
 		mockDatasetClient := &mock.DatasetClientMock{

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -141,7 +141,7 @@ func TestS3URL(t *testing.T) {
 
 func TestHandleMessage(t *testing.T) {
 
-	Convey("Given a panic occurs when ", t, func() {
+	Convey("Given a panic occurs when GetInstance is called ", t, func() {
 		datasetClient := &mock.DatasetClientMock{
 			GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string) (dataset.Instance, error) {
 				panic("panic message")
@@ -346,7 +346,6 @@ func TestHandleMessage(t *testing.T) {
 					NumberOfObservations: 1})
 			})
 		})
-
 	})
 }
 


### PR DESCRIPTION
### What
- fix convey message in `service/service_test.go`
- remove 'spew' of the panic error when a panic is caught. The existing error log proved sufficient.
- Separate file read from dimension post
Posting the dimensions to the dataset API as they are read from the file means the file reader is open for an unnecessary amount of time. For large datasets this increases the chance of getting connection reset errors from S3. Separating the file reading from the dimension posting allows the file to be read much quicker.

The `Extract` function now just returns the identified dimension options in the current line, whereas before it was adding them to the global map of dimensions. I have moved this logic out of the extract function into service.go, to keep the extract function focussed only on extracting data from the CSV row.

### How to review
Review changes / check tests pass

Integration test if you dare 😄 

### Who can review
Anyone
