### PR TITLE
Update to use dp-api-clients-go v.2.0.6-beta

### DIFF
--- a/dimension/extraction.go
+++ b/dimension/extraction.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	dataset "github.com/ONSdigital/dp-api-clients-go/dataset"
+	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 )
 
 // Extract represents all information needed to extract dimensions

--- a/dimension/extraction_test.go
+++ b/dimension/extraction_test.go
@@ -3,7 +3,7 @@ package dimension_test
 import (
 	"testing"
 
-	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-dimension-extractor/dimension"
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-dimension-extractor
 go 1.16
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.34.2
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
 	github.com/ONSdigital/dp-reporter-client v1.0.1
@@ -13,7 +13,6 @@ require (
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/Shopify/sarama v1.28.0 // indirect
 	github.com/aws/aws-sdk-go v1.38.1
-	github.com/fatih/color v1.10.0 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -21,13 +20,11 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.8 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
-	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/smartystreets/goconvey v1.6.4
 	golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670 // indirect
 	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4
-	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.34.2 h1:4oVv0YbpxZn4V1H/X7RFQqlAPdXBlthKTarvrDq+tbU=
-github.com/ONSdigital/dp-api-clients-go v1.34.2/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
+github.com/ONSdigital/dp-api-clients-go v1.34.3 h1:nS3ZG3Eql9T68Q0IFehpnqkUy2AFoTDktVgaD90Yj+s=
+github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta h1:Wbjibp0/LLoRewWQfmbWw26iKDixw+iiA42OQgRqTQ4=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta/go.mod h1:zN8+84r1tWgyCmypku7JFN63nCMOGTIM26zf5GwHkJ4=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
@@ -41,6 +43,7 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQ
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
+github.com/ONSdigital/log.go/v2 v2.0.0/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/ONSdigital/s3crypto v0.0.0-20180725145621-f8943119a487 h1:gQ8g6w/Pe2e1bt1Ht//tQXPxNpwHFcPbi09MRGKH0eM=
 github.com/ONSdigital/s3crypto v0.0.0-20180725145621-f8943119a487/go.mod h1:sYVkbMGvEplxktSXXSOVMQgGOuhqIXX5qBns81v1vas=
 github.com/Shopify/sarama v1.27.0 h1:tqo2zmyzPf1+gwTTwhI6W+EXDw4PVSczynpHKFtVAmo=
@@ -326,8 +329,8 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0 h1:g9s1Ppvvun/fI+BptTMj909BBIcGrzQ32k9FNlcevOE=
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -9,9 +9,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/ONSdigital/dp-api-clients-go/dataset"
-	"github.com/ONSdigital/dp-api-clients-go/health"
-	"github.com/ONSdigital/dp-api-clients-go/identity"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/health"
+	"github.com/ONSdigital/dp-api-clients-go/v2/identity"
 	"github.com/ONSdigital/dp-dimension-extractor/config"
 	"github.com/ONSdigital/dp-dimension-extractor/event"
 	"github.com/ONSdigital/dp-dimension-extractor/initialise"

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -3,7 +3,7 @@ package service
 import (
 	"io"
 
-	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 	"golang.org/x/net/context"
@@ -28,9 +28,9 @@ type S3Client interface {
 
 // DatasetClient is an interface to represent methods called to action upon Dataset REST interface
 type DatasetClient interface {
-	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID string) (m dataset.Instance, err error)
-	PostInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data dataset.OptionPost) error
-	PutInstanceData(ctx context.Context, serviceAuthToken, instanceID string, data dataset.JobInstance) error
+	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID, ifMatch string) (m dataset.Instance, eTag string, err error)
+	PostInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data dataset.OptionPost, ifMatch string) (eTag string, err error)
+	PutInstanceData(ctx context.Context, serviceAuthToken, instanceID string, data dataset.JobInstance, ifMatch string) (eTag string, err error)
 }
 
 // KafkaProducer is an interface to represent methods called to action upon Kafka to produce messages

--- a/service/mock/dataset.go
+++ b/service/mock/dataset.go
@@ -5,7 +5,7 @@ package mock
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-dimension-extractor/service"
 	"sync"
 )
@@ -37,13 +37,13 @@ var _ service.DatasetClient = &DatasetClientMock{}
 //     }
 type DatasetClientMock struct {
 	// GetInstanceFunc mocks the GetInstance method.
-	GetInstanceFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string) (dataset.Instance, error)
+	GetInstanceFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error)
 
 	// PostInstanceDimensionsFunc mocks the PostInstanceDimensions method.
-	PostInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost) error
+	PostInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error)
 
 	// PutInstanceDataFunc mocks the PutInstanceData method.
-	PutInstanceDataFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.JobInstance) error
+	PutInstanceDataFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.JobInstance, ifMatch string) (string, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -59,6 +59,8 @@ type DatasetClientMock struct {
 			CollectionID string
 			// InstanceID is the instanceID argument value.
 			InstanceID string
+			// If is the instanceID argument value.
+			IfMatch string
 		}
 		// PostInstanceDimensions holds details about calls to the PostInstanceDimensions method.
 		PostInstanceDimensions []struct {
@@ -89,7 +91,7 @@ type DatasetClientMock struct {
 }
 
 // GetInstance calls GetInstanceFunc.
-func (mock *DatasetClientMock) GetInstance(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string) (dataset.Instance, error) {
+func (mock *DatasetClientMock) GetInstance(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
 	if mock.GetInstanceFunc == nil {
 		panic("DatasetClientMock.GetInstanceFunc: method is nil but DatasetClient.GetInstance was just called")
 	}
@@ -99,17 +101,19 @@ func (mock *DatasetClientMock) GetInstance(ctx context.Context, userAuthToken st
 		ServiceAuthToken string
 		CollectionID     string
 		InstanceID       string
+		IfMatch          string
 	}{
 		Ctx:              ctx,
 		UserAuthToken:    userAuthToken,
 		ServiceAuthToken: serviceAuthToken,
 		CollectionID:     collectionID,
 		InstanceID:       instanceID,
+		IfMatch:          ifMatch,
 	}
 	mock.lockGetInstance.Lock()
 	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
 	mock.lockGetInstance.Unlock()
-	return mock.GetInstanceFunc(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID)
+	return mock.GetInstanceFunc(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, ifMatch)
 }
 
 // GetInstanceCalls gets all the calls that were made to GetInstance.
@@ -121,6 +125,7 @@ func (mock *DatasetClientMock) GetInstanceCalls() []struct {
 	ServiceAuthToken string
 	CollectionID     string
 	InstanceID       string
+	IfMatch          string
 } {
 	var calls []struct {
 		Ctx              context.Context
@@ -128,6 +133,7 @@ func (mock *DatasetClientMock) GetInstanceCalls() []struct {
 		ServiceAuthToken string
 		CollectionID     string
 		InstanceID       string
+		IfMatch          string
 	}
 	mock.lockGetInstance.RLock()
 	calls = mock.calls.GetInstance
@@ -136,7 +142,7 @@ func (mock *DatasetClientMock) GetInstanceCalls() []struct {
 }
 
 // PostInstanceDimensions calls PostInstanceDimensionsFunc.
-func (mock *DatasetClientMock) PostInstanceDimensions(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost) error {
+func (mock *DatasetClientMock) PostInstanceDimensions(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
 	if mock.PostInstanceDimensionsFunc == nil {
 		panic("DatasetClientMock.PostInstanceDimensionsFunc: method is nil but DatasetClient.PostInstanceDimensions was just called")
 	}
@@ -154,7 +160,7 @@ func (mock *DatasetClientMock) PostInstanceDimensions(ctx context.Context, servi
 	mock.lockPostInstanceDimensions.Lock()
 	mock.calls.PostInstanceDimensions = append(mock.calls.PostInstanceDimensions, callInfo)
 	mock.lockPostInstanceDimensions.Unlock()
-	return mock.PostInstanceDimensionsFunc(ctx, serviceAuthToken, instanceID, data)
+	return mock.PostInstanceDimensionsFunc(ctx, serviceAuthToken, instanceID, data, ifMatch)
 }
 
 // PostInstanceDimensionsCalls gets all the calls that were made to PostInstanceDimensions.
@@ -179,7 +185,7 @@ func (mock *DatasetClientMock) PostInstanceDimensionsCalls() []struct {
 }
 
 // PutInstanceData calls PutInstanceDataFunc.
-func (mock *DatasetClientMock) PutInstanceData(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.JobInstance) error {
+func (mock *DatasetClientMock) PutInstanceData(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.JobInstance, ifMatch string) (string, error) {
 	if mock.PutInstanceDataFunc == nil {
 		panic("DatasetClientMock.PutInstanceDataFunc: method is nil but DatasetClient.PutInstanceData was just called")
 	}
@@ -197,7 +203,7 @@ func (mock *DatasetClientMock) PutInstanceData(ctx context.Context, serviceAuthT
 	mock.lockPutInstanceData.Lock()
 	mock.calls.PutInstanceData = append(mock.calls.PutInstanceData, callInfo)
 	mock.lockPutInstanceData.Unlock()
-	return mock.PutInstanceDataFunc(ctx, serviceAuthToken, instanceID, data)
+	return mock.PutInstanceDataFunc(ctx, serviceAuthToken, instanceID, data, ifMatch)
 }
 
 // PutInstanceDataCalls gets all the calls that were made to PutInstanceData.

--- a/service/service.go
+++ b/service/service.go
@@ -69,7 +69,7 @@ func (svc *Service) HandleMessage(ctx context.Context, message kafka.Message) (s
 	}
 	defer file.Close()
 
-	codeLists, _, err := svc.DatasetClient.GetInstance(ctx, "", svc.AuthToken, "", instanceID, "")
+	codeLists, _, err := svc.DatasetClient.GetInstance(ctx, "", svc.AuthToken, "", instanceID, headers.IfMatchAnyETag)
 	if err != nil {
 		log.Event(ctx, "encountered error immediately when requesting data from the dataset api", log.ERROR, log.Error(err), log.Data{"instance_id": instanceID})
 		return instanceID, err

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-dimension-extractor/schema"
 	"github.com/ONSdigital/dp-dimension-extractor/service"
 	"github.com/ONSdigital/dp-dimension-extractor/service/mock"
@@ -56,17 +56,17 @@ var ctx = context.Background()
 // mock functions for testing
 var (
 	mockChannelsFunc    = func() *kafka.ProducerChannels { return testChannels }
-	mockGetInstanceFunc = func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string) (dataset.Instance, error) {
+	mockGetInstanceFunc = func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
 		if instanceID == validInstanceID {
-			return testInstance, nil
+			return testInstance, "", nil
 		}
-		return dataset.Instance{}, errors.New("Unexpected instance ID")
+		return dataset.Instance{}, "", errors.New("Unexpected instance ID")
 	}
-	mockPostInstanceFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost) error {
-		return nil
+	mockPostInstanceFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
+		return "", nil
 	}
-	mockPutInstanceFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.JobInstance) error {
-		return nil
+	mockPutInstanceFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.JobInstance, ifMatch string) (string, error) {
+		return "", nil
 	}
 
 	mockGetFunc = func(key string) (io.ReadCloser, *int64, error) {


### PR DESCRIPTION
### What

Update to use dp-api-clients-go v.2.0.6-beta
Trello - https://trello.com/c/4qMsreiP/5162-update-services-to-use-dataset-api-etag-if-match-8

### How to review

Confirm changes are correct

### Who can review

Anyone
