### PR TITLE
upgrade dp-kafka to v2.4.3 for healtcheck WARNING fix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ func getDefaultConfig() *Config {
 		EncryptionDisabled:      false,
 		GracefulShutdownTimeout: 5 * time.Second,
 		KafkaConfig: KafkaConfig{
-			BindAddr:                 []string{"localhost:9092"},
+			BindAddr:                 []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 			MaxBytes:                 "2000000",
 			Version:                  "1.0.2",
 			SecProtocol:              "",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,7 @@ func TestGet(t *testing.T) {
 					So(cfg.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
 					So(cfg.EncryptionDisabled, ShouldEqual, false)
 					So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
-					So(cfg.KafkaConfig.BindAddr[0], ShouldEqual, "localhost:9092")
+					So(cfg.KafkaConfig.BindAddr, ShouldResemble, []string{"localhost:9092", "localhost:9093", "localhost:9094"})
 					So(cfg.KafkaConfig.MaxBytes, ShouldEqual, "2000000")
 					So(cfg.KafkaConfig.Version, ShouldEqual, "1.0.2")
 					So(cfg.KafkaConfig.SecProtocol, ShouldEqual, "")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go v1.42.0 // indirect
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.16
 	github.com/ONSdigital/dp-healthcheck v1.1.2
-	github.com/ONSdigital/dp-kafka/v2 v2.4.1
+	github.com/ONSdigital/dp-kafka/v2 v2.4.3
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/dp-reporter-client v1.1.0
 	github.com/ONSdigital/dp-s3 v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0r
 github.com/ONSdigital/dp-healthcheck v1.1.2 h1:IE4G9/jGLLBoQo8DOdPdmrD3igVfmTEWe7dryg+BI98=
 github.com/ONSdigital/dp-healthcheck v1.1.2/go.mod h1:NhfezqsFUBufxaN8w+b0eF5Ps4i1K1ikAw7ITKjyAuc=
 github.com/ONSdigital/dp-kafka/v2 v2.0.2/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1 h1:e4nTpfsqb/gRRF3ZgstZ8mEjONvt+QPoWKbZoRg5dU8=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3 h1:Sb5nc4M3RsDMDmclsTqyjTMP6IBD7dRkv3kaIM26LLs=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=


### PR DESCRIPTION
### What

- Upgrade `dp-kafka` dependency to v2.4.3 to use the healthcheck fix where kafka producers/consumers will have a `warning` health (instead of `critical`) if enough brokers are available
  - min 2 brokers for producers
  - min 1 broker for consumers
- kafkaAddr match brokers in dp-compose

### How to review

Make sure `dp-kafka` dependency is upgraded

### Who can review

anyone